### PR TITLE
Accept complex parameters as JSON strings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,3 +18,33 @@ jobs:
         with:
           route: GET /repos/:owner/:repo/releases/latest
       - run: "echo latest release: '${{ steps.get_latest_release.outputs.data }}'"
+      # Create check run
+      - uses: ./
+        id: create_check_run
+        with:
+          route: POST /repos/:owner/:repo/check-runs
+          mediaType: '{"previews": ["antiope"]}'
+          name: 'Test check run'
+          head_sha: ${{ github.sha }}
+          output: '{"title":"Test check run title","summary": "A summary of the test check run", "images": [{"alt": "Test image", "image_url": "https://octodex.github.com/images/jetpacktocat.png"}]}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      # Parse steps.create_check_run.outputs.data, since it is a string
+      - id: parse_create_check_run
+        uses: gr2m/get-json-paths-action@v1.x
+        with:
+          json: ${{ steps.create_check_run.outputs.data }}
+          id: "id"
+          
+      # Update check run to completed, succesful status
+      - uses: ./
+        id: update_check_run
+        with:
+          route: PATCH /repos/:owner/:repo/check-runs/:check_run_id
+          mediaType: '{"previews": ["antiope"]}'
+          check_run_id: ${{ steps.parse_create_check_run.outputs.id }}
+          conclusion: 'success'
+          status: 'completed'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const { inspect } = require("util");
+const yaml = require("js-yaml");
 
 const core = require("@actions/core");
 const { Octokit } = require("@octokit/action");
@@ -56,8 +57,12 @@ function getAllInputs() {
   return Object.entries(process.env).reduce((result, [key, value]) => {
     if (!/^INPUT_/.test(key)) return result;
 
-    const inputName = key.toLowerCase() === 'input_mediatype' ? 'mediaType' : key.substr("INPUT_".length).toLowerCase();
-    result[inputName] = value;
+    const inputName =
+      key.toLowerCase() === "input_mediatype"
+        ? "mediaType"
+        : key.substr("INPUT_".length).toLowerCase();
+    result[inputName] = yaml.safeLoad(value);
+
     return result;
   }, {});
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -449,7 +449,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -923,8 +922,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esutils": {
       "version": "2.0.3",
@@ -1392,7 +1390,6 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -5843,8 +5840,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "stream-combiner2": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "license": "MIT",
   "dependencies": {
     "@actions/core": "^1.1.1",
-    "@octokit/action": "^1.0.0"
+    "@octokit/action": "^1.0.0",
+    "js-yaml": "^3.13.1"
   },
   "devDependencies": {
     "@semantic-release/git": "^7.0.16",


### PR DESCRIPTION
Hi there! 👋This PR contains two updates:
1. Accept arrays as `INPUT_`s by using `js-yaml.safeLoad()` to parse the `yaml` input into `js`. So:
```yaml
INPUT_REQUIRED_CONTEXTS: '[]'
```

is parsed into:

```js
parameters = {
  required_contexts: []
}
```

instead of:
```js
parameters = {
  required_contexts: '[]'
}
```
This is necessary for many v3 API calls like [Create Deployment](https://developer.github.com/v3/repos/deployments/).

2. I also updated the documentation to describe how to use `INPUT_`s like this.

---
Happy to hear your thoughts and find out if there are other ways to do what I've PR'd. Thanks! 🙏 