### PR TITLE
Fix: make exception NOT to lowercase mediaType

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function getAllInputs() {
   return Object.entries(process.env).reduce((result, [key, value]) => {
     if (!/^INPUT_/.test(key)) return result;
 
-    const inputName = key.substr("INPUT_".length).toLowerCase();
+    const inputName = key.toLowerCase() === 'input_mediatype' ? 'mediaType' : key.substr("INPUT_".length).toLowerCase();
     result[inputName] = value;
     return result;
   }, {});


### PR DESCRIPTION
As @gr2m [noticed](https://github.com/octokit/request-action/pull/2#discussion_r341696620) in the other parallel pull request, it is pretty simple to make an exception for `mediaType` such that it gets passed through to `@octokit/request` correctly.