### PR TITLE
simplify JSON parsing with fromJson function

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,22 +34,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Parse steps.create_check_run.outputs.data, since it is a string
-      - id: parse_create_check_run
-        uses: gr2m/get-json-paths-action@v1.x
-        with:
-          json: ${{ steps.create_check_run.outputs.data }}
-          id: "id"
-
       # Update check run to completed, succesful status
-      - name: "Update check run ${{ steps.parse_create_check_run.outputs.id }} "
+      - name: "Update check run ${{ fromJson(steps.create_check_run.outputs.data).id }} "
         uses: ./
         id: update_check_run
         with:
           route: PATCH /repos/:repository/check-runs/:check_run_id
           repository: ${{ github.repository }}
           mediaType: '{"previews": ["antiope"]}'
-          check_run_id: ${{ steps.parse_create_check_run.outputs.id }}
+          check_run_id: ${{ fromJson(steps.create_check_run.outputs.data).id }}
           conclusion: "success"
           status: "completed"
         env:


### PR DESCRIPTION
GitHub recently added a [fromJson](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#fromjson) function ([announcement](https://github.blog/changelog/2020-04-15-github-actions-new-workflow-features/)). It's no longer necessary now to use an additional action to parse the JSON response from this action. This PR updates the documentation and the tests.