### PR TITLE
Add note about warnings to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ The actions sets `data` output to the response data. The action also sets the `h
 
 To access deep values of `outputs.data` and `outputs.headers`, check out the [fromJson](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#fromjson) function.
 
+## Warnings
+
+The GitHub Actions runners are currently showing warnings when using this action that look like:
+
+```
+##[warning]Unexpected input 'repository', valid inputs are ['route', 'mediaType']
+```
+
+The reason for this warning is because the `repository` key is not listed as a possible value in `actions.yml`. This warning will appear for any key used under the `with` except `route` and `mediaType`. Due to the flexible nature of the required inputs depending on the `route`, not all of the possible paramters can be listed in `actions.yml`, so you will see this warning under normal usage of the action. As long as you see a 200 response code at the bottom of the output, everything should have worked properly and you can ignore the warnings. The response code will appear at the bottom of the output from the action and looks like:
+
+```
+< 200 451ms
+```
+
+See [Issue #26](https://github.com/octokit/request-action/issues/26) for more information.
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
Add some text explaining the cause of the warnings that are shown when using this action. The warnings are normal and can be ignored as long as a 200 status code is returned. Related to #26.