### PR TITLE
docs(README): add missing double quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: "Release found: ${{ steps.get_release.outputs.data }}"
-      - name: "Release cound not be found. Request failed with status ${{ steps.get_release.outputs.status }}
+      - name: "Release cound not be found. Request failed with status ${{ steps.get_release.outputs.status }}"
         if: ${{ failure() }}
 ```
 


### PR DESCRIPTION
Thank you for developing and maintaining this GH Action.

Here is a very small PR fixing a double quote missing at the end of a line in "Handle errors" example.