### PR TITLE
Fix support for requesting a custom media type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,3 +102,23 @@ jobs:
           repository: ${{ github.repository }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  media_type:
+    name: "[TEST] Media Type"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+      - uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93 # tag=v3
+        with:
+          node-version: 16
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Make a request with a custom media type
+        uses: ./
+        with:
+          route: GET /repos/{owner}/{repo}/contents/README.md
+          owner: octokit
+          repo: request-action
+          mediaType: raw
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,9 @@ inputs:
     description: "HTTP Verb + path as shown on https://developer.github.com/v3/"
     required: true
   mediaType:
-    description: "Custom media type in the Accept header"
+    description: "Media type to request in the `Accept` header. Supports values allowed by the `options.mediaType.format` option in <https://github.com/octokit/endpoint.js>."
     required: false
-    default: "{}"
+    default: json
 outputs:
   status:
     description: "Response status code."

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ async function main() {
 
   try {
     const octokit = new Octokit();
-    const { route, ...parameters } = getAllInputs();
+    const { route, mediaType, ...parameters } = getAllInputs();
 
     core.info(route);
     for (const [name, value] of Object.entries(parameters)) {
@@ -20,10 +20,10 @@ async function main() {
 
     // workaround for https://github.com/octokit/request-action/issues/71
     // un-encode "repo" in /repos/{repo} URL when "repo" parameter is set to ${{ github.repository }}
-    const { url, body, ...options } = octokit.request.endpoint(
-      route,
-      parameters
-    );
+    const { url, body, ...options } = octokit.request.endpoint(route, {
+      ...parameters,
+      mediaType: { format: mediaType },
+    });
     const requestOptions = {
       ...options,
       data: body,


### PR DESCRIPTION
This action supports passing a custom `mediaType`, but this doesn't actually work. The action receives a string, but `octokit/endpoint.js` [expects][1] to be passed an object with
`format` and/or `previews` keys.

Trying to pass a `mediaType` value as suggested in the `action.yml` leads to a `Cannot read property 'map' of undefined` error which comes from [`endpoint.js`'s `merge` function][2] which is assuming that the passed `mediaType` will be an object with properties.

This fixes the issue by taking the value passed in as `mediaType` and sending it to `endpoint.js` as `mediaType.format`.

There are other potential approaches we could take to this, for example:

* supporting a more basic `accept` option instead for a raw header
* accepting `mediaTypeFormat` and `mediaTypePreviews` (or similar)

Fixes https://github.com/octokit/request-action/issues/175.

[1]:
https://github.com/octokit/endpoint.js#endpointroute-options-or-endpointoptions
[2]:
https://github.com/octokit/endpoint.js/blob/8266fc12765e94cb966d5104a375631b4efb0dbf/src/merge.ts#L35-L37