### PR TITLE
docs(README): add example of how to set the response format with `mediaType` (#184)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,17 @@ jobs:
                 image_url: https://octodex.github.com/images/jetpacktocat.png
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+      # Download file
+      - uses: octokit/request-action@v2.x
+        id: download_file
+        with:
+          route: GET /repos/OWNER/REPO/contents/README.md
+          owner: octokit
+          repo: request-action
+          mediaType: | # The | is significant!
+            format: raw
+         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Update check run to completed, successful status
       - uses: octokit/request-action@v2.x
         id: update_check_run


### PR DESCRIPTION
This adds an example to the README of how to request a specific response format using the `mediaType` option, following the [very excellent advice of @gr2m](https://github.com/octokit/request-action/pull/176#issuecomment-1232291341).

Fixes #175.