### PR TITLE
docs(README): fix failing examples in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
           repo: request-action
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: "echo latest release: ${{ steps.get_latest_release.outputs.data }}"
+      - run: "echo latest release: '${{ steps.get_latest_release.outputs.data }}'"
 ```
 
 More complex examples involving `POST`, setting custom media types, and parsing output data
@@ -106,8 +106,8 @@ jobs:
           repo: request-action
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: "echo Release found: ${{ steps.get_release.outputs.data }}"
-      - run: "echo Release could not be found. Request failed with status ${{ steps.get_release.outputs.status }}"
+      - run: "echo Release found: '${{ steps.get_release.outputs.data }}'"
+      - run: "echo Release could not be found. Request failed with status '${{ steps.get_release.outputs.status }}'"
         if: ${{ failure() }}
 ```
 


### PR DESCRIPTION
Resolves #130

---

## Behavior

### Before the change?

The examples in the README that tried to echo GitHub Actions contexts incorrectly were failing. For example:

```
- run: "echo latest release: ${{ steps.get_latest_release.outputs.data }}"
```

Failing test job: https://github.com/9inpachi/git-testing/actions/runs/3896990385/jobs/6654168007
Failing test job workflow file: https://github.com/9inpachi/git-testing/actions/runs/3896990385/workflow

### After the change?

The GitHub Actions contexts that are used in the echo statements are wrapped in single quotes to be able to echo multiline strings with double quotes. For example, output of `${{ steps.get_latest_release.outputs.data }}` is a multiline string with double quotes and can be safely echo'd now.

```
- run: "echo latest release: '${{ steps.get_latest_release.outputs.data }}'"
```

Successful test job: https://github.com/9inpachi/git-testing/actions/runs/3897156229/jobs/6654529237
Successful test job workflow file: https://github.com/9inpachi/git-testing/actions/runs/3897156229/workflow